### PR TITLE
Fix build on GCC 10

### DIFF
--- a/src/include/zenmonitor.h
+++ b/src/include/zenmonitor.h
@@ -25,4 +25,4 @@ void sensor_init_free(SensorInit *s);
 gboolean check_zen();
 gchar *cpu_model();
 guint get_core_count();
-gboolean display_coreid;
+extern gboolean display_coreid;


### PR DESCRIPTION
Variable declarations in header files need the extern keyword to not cause duplication definition errors.
Closes #25.