### PR TITLE
Implement commandline and csv output

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,28 @@
+CC := cc
+
 ifeq ($(PREFIX),)
 	PREFIX := /usr/local
 endif
 
+BUILD_FILES_COMMON := \
+	src/ss/*.c \
+	src/sysfs.c \
+	src/zenmonitor-lib.c
+
+BUILD_FILES_GUI := \
+	$(BUILD_FILES_COMMON) \
+	src/gui.c \
+	src/zenmonitor.c
+
+BUILD_FILES_CLI := \
+	$(BUILD_FILES_COMMON) \
+	src/zenmonitor-cli.c
+
 build:
-	cc -Isrc/include `pkg-config --cflags gtk+-3.0` src/*.c src/ss/*.c -o zenmonitor `pkg-config --libs gtk+-3.0` -lm -no-pie -Wall
+	$(CC) -Isrc/include `pkg-config --cflags gtk+-3.0` $(BUILD_FILES_GUI) -o zenmonitor `pkg-config --libs gtk+-3.0` -lm -no-pie -Wall $(CFLAGS)
+
+build-cli:
+	$(CC) -Isrc/include `pkg-config --cflags glib-2.0` $(BUILD_FILES_CLI) -o zenmonitor-cli `pkg-config --libs glib-2.0` -lm -no-pie -Wall $(CFLAGS)
 
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
@@ -13,6 +32,10 @@ install:
 	sed -e "s|@APP_EXEC@|${DESTDIR}${PREFIX}/bin/zenmonitor|" \
 			data/zenmonitor.desktop.in > \
 			$(DESTDIR)$(PREFIX)/share/applications/zenmonitor.desktop
+
+install-cli:
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	install -m 755 zenmonitor-cli $(DESTDIR)$(PREFIX)/bin
 
 install-polkit:
 	sed -e "s|@APP_EXEC@|${DESTDIR}${PREFIX}/bin/zenmonitor|" \
@@ -29,5 +52,9 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/zenmonitor-root.desktop
 	rm -f $(DESTDIR)/usr/share/polkit-1/actions/org.pkexec.zenmonitor.policy
 
+all: build build-cli
+
 clean:
 	rm -f zenmonitor
+	rm -f zenmonitor-cli
+	rm -f *.o

--- a/src/gui.c
+++ b/src/gui.c
@@ -1,5 +1,6 @@
 #include <cpuid.h>
 #include <gtk/gtk.h>
+#include <stdio.h>
 #include "gui.h"
 #include "zenmonitor.h"
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1,6 +1,5 @@
 #include <cpuid.h>
 #include <gtk/gtk.h>
-#include <stdio.h>
 #include "gui.h"
 #include "zenmonitor.h"
 

--- a/src/include/gui.h
+++ b/src/include/gui.h
@@ -1,1 +1,6 @@
+#ifndef __ZENMONITOR_GUI_H__
+#define __ZENMONITOR_GUI_H__
+
 int start_gui();
+
+#endif /* __ZENMONITOR_GUI_H__ */

--- a/src/include/msr.h
+++ b/src/include/msr.h
@@ -1,4 +1,11 @@
+#ifndef __ZENMONITOR_MSR_H__
+#define __ZENMONITOR_MSR_H__
+
+#include <glib.h>
+
 gboolean msr_init();
 void msr_update();
 void msr_clear_minmax();
 GSList* msr_get_sensors();
+
+#endif /* __ZENMONITOR_MSR_H__ */

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -1,4 +1,11 @@
+#ifndef __ZENMONITOR_OS_H__
+#define __ZENMONITOR_OS_H__
+
+#include <glib.h>
+
 gboolean os_init(void);
 void os_update(void);
 void os_clear_minmax(void);
 GSList* os_get_sensors(void);
+
+#endif /* __ZENMONITOR_OS_H__ */

--- a/src/include/sysfs.h
+++ b/src/include/sysfs.h
@@ -1,3 +1,8 @@
+#ifndef __ZENMONITOR_SYSFS_H__
+#define __ZENMONITOR_SYSFS_H__
+
+#include <glib.h>
+
 #define SYSFS_DIR_CPUS "/sys/devices/system/cpu"
 
 struct cpudev {
@@ -6,3 +11,5 @@ struct cpudev {
 };
 
 struct cpudev * get_cpu_dev_ids(void);
+
+#endif /* __ZENMONITOR_SYSFS_H__ */

--- a/src/include/zenmonitor.h
+++ b/src/include/zenmonitor.h
@@ -1,3 +1,8 @@
+#ifndef __ZENMONITOR_ZENMONITOR_H__
+#define __ZENMONITOR_ZENMONITOR_H__
+
+#include <glib.h>
+
 #define ERROR_VALUE -999.0
 #define VERSION "1.4.2"
 
@@ -28,3 +33,5 @@ gboolean check_zen();
 gchar *cpu_model();
 guint get_core_count();
 extern gboolean display_coreid;
+
+#endif /* __ZENMONITOR_ZENMONITOR_H__ */

--- a/src/include/zenmonitor.h
+++ b/src/include/zenmonitor.h
@@ -1,6 +1,7 @@
 #ifndef __ZENMONITOR_ZENMONITOR_H__
 #define __ZENMONITOR_ZENMONITOR_H__
 
+#include <time.h>
 #include <glib.h>
 
 #define ERROR_VALUE -999.0
@@ -27,11 +28,23 @@ typedef struct {
     GSList *sensors;
 } SensorSource;
 
+typedef struct {
+    GPtrArray *labels;
+    GPtrArray *data;
+    GArray *time;
+} SensorDataStore;
+
 SensorInit* sensor_init_new(void);
 void sensor_init_free(SensorInit *s);
 gboolean check_zen();
 gchar *cpu_model();
 guint get_core_count();
+SensorDataStore* sensor_data_store_new();
+void sensor_data_store_add_entry(SensorDataStore *store, gchar *entry);
+gint sensor_data_store_drop_entry(SensorDataStore *store, gchar *entry);
+void sensor_data_store_keep_time(SensorDataStore *store);
+gint sensor_data_store_add_data(SensorDataStore *store, gchar *entry, float data);
+void sensor_data_store_free(SensorDataStore *store);
 extern gboolean display_coreid;
 
 #endif /* __ZENMONITOR_ZENMONITOR_H__ */

--- a/src/include/zenpower.h
+++ b/src/include/zenpower.h
@@ -1,4 +1,11 @@
+#ifndef __ZENMONITOR_ZENPOWER_H__
+#define __ZENMONITOR_ZENPOWER_H__
+
+#include <glib.h>
+
 gboolean zenpower_init();
 GSList* zenpower_get_sensors();
 void zenpower_update();
 void zenpower_clear_minmax();
+
+#endif /* __ZENMONITOR_ZENPOWER_H__ */

--- a/src/zenmonitor-cli.c
+++ b/src/zenmonitor-cli.c
@@ -1,0 +1,127 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "msr.h"
+#include "os.h"
+#include "zenpower.h"
+#include "zenmonitor.h"
+
+gboolean display_coreid = 0;
+gdouble delay = 0.5;
+gchar *format = "";
+gchar *columns[2048];
+
+static GOptionEntry options[] =
+{
+    { "format", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &format, "Output format (csv, json)", "FORMAT" },
+    { "delay", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_DOUBLE, &delay, "Interval of refreshing informations", "SECONDS" },
+    { "coreid", 'c', 0, G_OPTION_ARG_NONE, &display_coreid, "Display core_id instead of core index", NULL },
+    { NULL }
+};
+
+static SensorSource sensor_sources[] = {
+    {
+        "zenpower",
+        zenpower_init, zenpower_get_sensors, zenpower_update, zenpower_clear_minmax,
+        FALSE, NULL
+    },
+    {
+        "msr",
+        msr_init, msr_get_sensors, msr_update, msr_clear_minmax,
+        FALSE, NULL
+    },
+    {
+        "os",
+        os_init, os_get_sensors, os_update, os_clear_minmax,
+        FALSE, NULL
+    },
+    {
+        NULL
+    }
+};
+
+void init_sensors() {
+    GSList *sensor;
+    SensorSource *source;
+    const SensorInit *data;
+    guint i = 0;
+
+    for(source = sensor_sources; source->drv; source++)
+    {
+        if(source->func_init())
+        {
+            source->sensors = source->func_get_sensors();
+            if(source->sensors != NULL)
+            {
+                source->enabled = TRUE;
+                sensor = source->sensors;
+                while(sensor)
+                {
+                    data = (SensorInit*)sensor->data;
+                    columns[i++] = data->label;
+                    sensor = sensor->next;
+                }
+            }
+        }
+    }
+    columns[i] = NULL;
+}
+
+void update_data()
+{
+    SensorSource *source;
+    GSList *node;
+    const SensorInit *sensorData;
+
+    for(source = sensor_sources; source->drv; source++)
+    {
+        if(source->enabled)
+        {
+            source->func_update();
+            if(source->sensors)
+            {
+                node = source->sensors;
+
+                while(node)
+                {
+                    sensorData = (SensorInit*)node->data;
+                    printf("%s\t%f\n", sensorData->label, *sensorData->value);
+                    node = node->next;
+                }
+            }
+        }
+    }
+}
+
+void start_watching()
+{
+    guint i = 0;
+    while(columns[i])
+    {
+        printf("%s\n", columns[i++]);
+    }
+
+    while(1)
+    {
+        update_data();
+        usleep(delay * 1000 * 1000);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    GError *error = NULL;
+    GOptionContext *context;
+
+    context = g_option_context_new("- Zenmonitor options");
+    g_option_context_add_main_entries(context, options, NULL);
+    if(!g_option_context_parse(context, &argc, &argv, &error)) {
+        g_print ("option parsing failed: %s\n", error->message);
+        exit (1);
+    }
+
+    init_sensors();
+    start_watching();
+
+    return EXIT_SUCCESS;
+}

--- a/src/zenmonitor-lib.c
+++ b/src/zenmonitor-lib.c
@@ -1,0 +1,94 @@
+#include <cpuid.h>
+
+#include "zenpower.h"
+#include "msr.h"
+#include "os.h"
+#include "zenmonitor.h"
+
+#define AMD_STRING "AuthenticAMD"
+#define ZEN_FAMILY 0x17
+
+// AMD PPR = https://www.amd.com/system/files/TechDocs/54945_PPR_Family_17h_Models_00h-0Fh.pdf
+
+gboolean check_zen() {
+    guint32 eax = 0, ebx = 0, ecx = 0, edx = 0, ext_family;
+    char vendor[13];
+
+    __get_cpuid(0, &eax, &ebx, &ecx, &edx);
+
+    memcpy(vendor, &ebx, 4);
+    memcpy(vendor+4, &edx, 4);
+    memcpy(vendor+8, &ecx, 4);
+    vendor[12] = 0;
+
+    if (strcmp(vendor, AMD_STRING) != 0){
+        return FALSE;
+    }
+
+    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+
+    ext_family = ((eax >> 8) & 0xF) + ((eax >> 20) & 0xFF);
+    if (ext_family != ZEN_FAMILY){
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+gchar *cpu_model() {
+    guint32 eax = 0, ebx = 0, ecx = 0, edx = 0;
+    char model[48];
+
+    // AMD PPR: page 65-68 - CPUID_Fn80000002_EAX-CPUID_Fn80000004_EDX
+    __get_cpuid(0x80000002, &eax, &ebx, &ecx, &edx);
+    memcpy(model, &eax, 4);
+    memcpy(model+4, &ebx, 4);
+    memcpy(model+8, &ecx, 4);
+    memcpy(model+12, &edx, 4);
+
+    __get_cpuid(0x80000003, &eax, &ebx, &ecx, &edx);
+    memcpy(model+16, &eax, 4);
+    memcpy(model+20, &ebx, 4);
+    memcpy(model+24, &ecx, 4);
+    memcpy(model+28, &edx, 4);
+
+    __get_cpuid(0x80000004, &eax, &ebx, &ecx, &edx);
+    memcpy(model+32, &eax, 4);
+    memcpy(model+36, &ebx, 4);
+    memcpy(model+40, &ecx, 4);
+    memcpy(model+44, &edx, 4);
+
+    model[48] = 0;
+    return g_strdup(g_strchomp(model));
+}
+
+guint get_core_count() {
+    guint eax = 0, ebx = 0, ecx = 0, edx = 0;
+    guint logical_cpus, threads_per_code;
+
+    // AMD PPR: page 57 - CPUID_Fn00000001_EBX
+    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+    logical_cpus = (ebx >> 16) & 0xFF;
+
+    // AMD PPR: page 82 - CPUID_Fn8000001E_EBX
+    __get_cpuid(0x8000001E, &eax, &ebx, &ecx, &edx);
+    threads_per_code = ((ebx >> 8) & 0xF) + 1;
+
+    if (threads_per_code == 0)
+        return logical_cpus;
+
+    return logical_cpus / threads_per_code;
+}
+
+SensorInit *sensor_init_new() {
+    return g_new0(SensorInit, 1);
+}
+
+void sensor_init_free(SensorInit *s) {
+    if (s) {
+        g_free(s->label);
+        g_free(s->hint);
+        g_free(s);
+    }
+}
+

--- a/src/zenmonitor.c
+++ b/src/zenmonitor.c
@@ -1,87 +1,14 @@
 #include <gtk/gtk.h>
-#include <cpuid.h>
 #include <string.h>
 #include <stdlib.h>
-#include "zenmonitor.h"
+
 #include "zenpower.h"
 #include "msr.h"
 #include "os.h"
 #include "gui.h"
+#include "zenmonitor.h"
 
-#define AMD_STRING "AuthenticAMD"
-#define ZEN_FAMILY 0x17
-
-// AMD PPR = https://www.amd.com/system/files/TechDocs/54945_PPR_Family_17h_Models_00h-0Fh.pdf
-
-gboolean check_zen() {
-    guint32 eax = 0, ebx = 0, ecx = 0, edx = 0, ext_family;
-    char vendor[13];
-
-    __get_cpuid(0, &eax, &ebx, &ecx, &edx);
-
-    memcpy(vendor, &ebx, 4);
-    memcpy(vendor+4, &edx, 4);
-    memcpy(vendor+8, &ecx, 4);
-    vendor[12] = 0;
-
-    if (strcmp(vendor, AMD_STRING) != 0){
-        return FALSE;
-    }
-
-    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-
-    ext_family = ((eax >> 8) & 0xF) + ((eax >> 20) & 0xFF);
-    if (ext_family != ZEN_FAMILY){
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-gchar *cpu_model() {
-    guint32 eax = 0, ebx = 0, ecx = 0, edx = 0;
-    char model[48];
-
-    // AMD PPR: page 65-68 - CPUID_Fn80000002_EAX-CPUID_Fn80000004_EDX
-    __get_cpuid(0x80000002, &eax, &ebx, &ecx, &edx);
-    memcpy(model, &eax, 4);
-    memcpy(model+4, &ebx, 4);
-    memcpy(model+8, &ecx, 4);
-    memcpy(model+12, &edx, 4);
-
-    __get_cpuid(0x80000003, &eax, &ebx, &ecx, &edx);
-    memcpy(model+16, &eax, 4);
-    memcpy(model+20, &ebx, 4);
-    memcpy(model+24, &ecx, 4);
-    memcpy(model+28, &edx, 4);
-
-    __get_cpuid(0x80000004, &eax, &ebx, &ecx, &edx);
-    memcpy(model+32, &eax, 4);
-    memcpy(model+36, &ebx, 4);
-    memcpy(model+40, &ecx, 4);
-    memcpy(model+44, &edx, 4);
-
-    model[48] = 0;
-    return g_strdup(g_strchomp(model));
-}
-
-guint get_core_count() {
-    guint eax = 0, ebx = 0, ecx = 0, edx = 0;
-    guint logical_cpus, threads_per_code;
-
-    // AMD PPR: page 57 - CPUID_Fn00000001_EBX
-    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-    logical_cpus = (ebx >> 16) & 0xFF;
-
-    // AMD PPR: page 82 - CPUID_Fn8000001E_EBX
-    __get_cpuid(0x8000001E, &eax, &ebx, &ecx, &edx);
-    threads_per_code = ((ebx >> 8) & 0xF) + 1;
-
-    if (threads_per_code == 0)
-        return logical_cpus;
-
-    return logical_cpus / threads_per_code;
-}
+gboolean display_coreid = 0;
 
 static SensorSource sensor_sources[] = {
     {
@@ -103,20 +30,6 @@ static SensorSource sensor_sources[] = {
         NULL
     }
 };
-
-SensorInit *sensor_init_new() {
-    return g_new0(SensorInit, 1);
-}
-
-void sensor_init_free(SensorInit *s) {
-    if (s) {
-        g_free(s->label);
-        g_free(s->hint);
-        g_free(s);
-    }
-}
-
-gboolean display_coreid = 0;
 
 static GOptionEntry options[] =
 {


### PR DESCRIPTION
This PR adds commandline mode.
It's simply flush info(same as displayed on gtk version) to stdout.

If file option given, zenmonitor-cli generates CSV file (like example on bottom)

CSV:
```
time(epoch),CPU Temperature (tCtl),CPU Temperature (tDie),CCD1 Temperature,CPU Core Voltage (SVI2),SOC Voltage (SVI2),CPU Core Current (SVI2),SOC Current (SVI2),CPU Core Power (SVI2),SOC Power (SVI2),Core 0 Frequency,Core 1 Frequency,Core 2 Frequency,Core 3 Frequency,Core 4 Frequency,Core 5 Frequency,Core 6 Frequency,Core 7 Frequency
1604848276.738761724,34.125000,34.125000,38.000000,1.475000,1.069000,7.905000,6.474000,11.659875,6.920706,2.270392,2.602216,3.880657,2.063959,2.200081,2.200115,2.200118,2.200113
1604848277.239861934,34.500000,34.500000,34.000000,0.975000,1.069000,1.317000,6.768000,1.284075,7.234992,2.042911,3.109526,2.797397,2.058353,2.199694,2.199800,2.200001,2.200009
1604848277.740219970,34.250000,34.250000,36.500000,0.988000,1.069000,2.635000,6.768000,2.603380,7.234992,2.070235,2.443443,2.532980,2.084690,2.199986,2.200086,2.200001,2.199991
1604848278.240584575,34.250000,34.250000,34.000000,0.994000,1.069000,1.317000,6.768000,1.964144,7.234992,2.101552,3.180403,2.607883,2.074437,2.199761,2.199930,2.199951,2.199715
1604848278.741001189,46.250000,46.250000,39.000000,0.994000,1.069000,1.976000,6.474000,1.964144,6.920706,2.050151,3.328964,3.065189,1.979954,2.199997,2.200075,2.200012,2.199738
```